### PR TITLE
REPORT 컬럼 구현

### DIFF
--- a/src/main/java/com/example/auction/common/config/RedisConfig.java
+++ b/src/main/java/com/example/auction/common/config/RedisConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -79,7 +80,15 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
     }
-
+    @Bean
+    @Qualifier("reportCounter")
+    public StringRedisTemplate reportCounterStringRedisTemplate(
+            @Qualifier("report") LettuceConnectionFactory connectionFactoryReport
+    ) {
+        var t = new StringRedisTemplate();
+        t.setConnectionFactory(connectionFactoryReport);
+        return t;
+    }
     // key = 3 product 관련 동시성 해결
     @Bean
     @Qualifier("bid")

--- a/src/main/java/com/example/auction/common/config/ReportRedisScriptsConfig.java
+++ b/src/main/java/com/example/auction/common/config/ReportRedisScriptsConfig.java
@@ -32,9 +32,9 @@ public class ReportRedisScriptsConfig {
     }
 
     /**
-     * pending에서 n만큼 빼되 음수 방지(거절 처리용)
-     * KEYS[1]=pendingKey, ARGV[1]=n
-     * return: 감소 후 pending 값
+     * 키에서 n만큼 빼되 음수 방지
+     * KEYS[1]=key, ARGV[1]=n
+     * return: 감소 후 값
      */
     @Bean("safeDecrPendingScript")
     public DefaultRedisScript<Long> safeDecrPendingScript() {

--- a/src/main/java/com/example/auction/common/config/ReportRedisScriptsConfig.java
+++ b/src/main/java/com/example/auction/common/config/ReportRedisScriptsConfig.java
@@ -1,0 +1,56 @@
+package com.example.auction.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+
+@Configuration
+public class ReportRedisScriptsConfig {
+
+    /**
+     * pending에서 n만큼 빼고(최소 0), accepted에 n만큼 더하는 원자 이동
+     * KEYS[1]=pendingKey, KEYS[2]=acceptedKey, ARGV[1]=n
+     * return: 이동 후 pending 값
+     */
+    @Bean("movePendingToAcceptedScript")
+    public DefaultRedisScript<Long> movePendingToAcceptedScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setResultType(Long.class);
+        script.setScriptText("""
+            local pending = redis.call('GET', KEYS[1])
+            if not pending then pending = '0' end
+            local n = tonumber(ARGV[1])
+            local p = tonumber(pending)
+            if p < n then n = p end
+            if n > 0 then
+              redis.call('DECRBY', KEYS[1], n)
+              redis.call('INCRBY', KEYS[2], n)
+            end
+            return tonumber(redis.call('GET', KEYS[1]) or '0')
+        """);
+        return script;
+    }
+
+    /**
+     * pending에서 n만큼 빼되 음수 방지(거절 처리용)
+     * KEYS[1]=pendingKey, ARGV[1]=n
+     * return: 감소 후 pending 값
+     */
+    @Bean("safeDecrPendingScript")
+    public DefaultRedisScript<Long> safeDecrPendingScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setResultType(Long.class);
+        script.setScriptText("""
+            local pending = redis.call('GET', KEYS[1])
+            if not pending then pending = '0' end
+            local n = tonumber(ARGV[1])
+            local p = tonumber(pending)
+            if n > p then n = p end
+            if n > 0 then
+              redis.call('DECRBY', KEYS[1], n)
+            end
+            return tonumber(redis.call('GET', KEYS[1]) or '0')
+        """);
+        return script;
+    }
+}

--- a/src/main/java/com/example/auction/report/controller/ReportController.java
+++ b/src/main/java/com/example/auction/report/controller/ReportController.java
@@ -8,6 +8,7 @@ import com.example.auction.report.dto.ReportResponseDto;
 import com.example.auction.report.service.ReportService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,6 +29,7 @@ public class ReportController {
     }
 
     // [관리자] 특정 유저의 특정 카테고리 신고 묶음 처리 (수락/반려)
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/admin/resolve/{targetUserId}/{category}")
     public ResponseEntity<CommonResDto> adminResolve(@PathVariable Long targetUserId,
                                                      @PathVariable ReportCategory category,
@@ -37,6 +39,7 @@ public class ReportController {
     }
 
     // [관리자] 즉시 정지
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/admin/suspend")
     public ResponseEntity<CommonResDto> adminSuspend(@RequestParam Long targetUserId,
                                                      @RequestParam long days,
@@ -46,6 +49,7 @@ public class ReportController {
     }
 
     // [관리자] 모든 제재 해제 (정지/임시정지 해제)
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/admin/lift")
     public ResponseEntity<CommonResDto> adminLift(@RequestParam Long targetUserId,
                                                   @RequestParam(required = false) String reason) {

--- a/src/main/java/com/example/auction/report/controller/ReportController.java
+++ b/src/main/java/com/example/auction/report/controller/ReportController.java
@@ -2,15 +2,21 @@ package com.example.auction.report.controller;
 
 import com.example.auction.common.dto.CommonResDto;
 import com.example.auction.report.domain.ReportCategory;
+import com.example.auction.report.domain.ReportStatus;
+import com.example.auction.report.dto.AdminReportGroupDto;
 import com.example.auction.report.dto.AdminResolveDto;
 import com.example.auction.report.dto.ReportCreateDto;
 import com.example.auction.report.dto.ReportResponseDto;
 import com.example.auction.report.service.ReportService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Controller
 @RequestMapping("/report")
@@ -37,6 +43,34 @@ public class ReportController {
         reportService.adminResolveCategoryForUser(targetUserId, category, adminResolveDto);
         return ResponseEntity.ok(new CommonResDto(HttpStatus.OK, "관리자 처리 완료", null));
     }
+
+    // [관리자] 묶음(그룹) 요약 리스트
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/admin/groups")
+    public ResponseEntity<CommonResDto> getAdminReportGroups(
+            @RequestParam(required = false) ReportCategory category,
+            @RequestParam(required = false) ReportStatus status,
+            @RequestParam(required = false) Integer minPending,
+            @RequestParam(required = false) Long targetUserId
+    ) {
+        List<AdminReportGroupDto> list = reportService.getAdminReportGroups(category, status, minPending, targetUserId);
+        return ResponseEntity.ok(new CommonResDto(HttpStatus.OK, "그룹 신고 목록 조회 성공", list));
+    }
+
+    // [관리자] 특정 그룹(타겟×카테고리) 상세 신고들 페이징
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/admin/groups/{targetUserId}/{category}")
+    public ResponseEntity<CommonResDto> getGroupReports(
+            @PathVariable Long targetUserId,
+            @PathVariable ReportCategory category,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        var pageRes = reportService.getGroupReports(targetUserId, category, pageable);
+        return ResponseEntity.ok(new CommonResDto(HttpStatus.OK, "그룹 신고 상세 조회 성공", pageRes));
+    }
+
 
     // [관리자] 즉시 정지
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/example/auction/report/domain/Report.java
+++ b/src/main/java/com/example/auction/report/domain/Report.java
@@ -24,7 +24,7 @@ public class Report extends BaseTimeEntity {
     private User reporter;
 
     // 신고당한 사람
-    @Column(nullable = false)
+    @Column(name = "target_id", nullable = false)
     private Long targetId;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/auction/report/domain/SuspendLevel.java
+++ b/src/main/java/com/example/auction/report/domain/SuspendLevel.java
@@ -1,11 +1,11 @@
 package com.example.auction.report.domain;
 
-public enum SuspendLevel {
-    NONE,
-    DAY_1,
-    DAY_3,
-    WEEK_1,
-    MONTH_1,
-    YEAR_1,
-    PERMANENT
-}
+//public enum SuspendLevel {
+//    NONE,
+//    DAY_1,
+//    DAY_3,
+//    WEEK_1,
+//    MONTH_1,
+//    YEAR_1,
+//    PERMANENT
+//}

--- a/src/main/java/com/example/auction/report/dto/AdminReportGroupDto.java
+++ b/src/main/java/com/example/auction/report/dto/AdminReportGroupDto.java
@@ -1,0 +1,46 @@
+package com.example.auction.report.dto;
+
+import com.example.auction.report.domain.ReportCategory;
+import com.example.auction.report.repository.ReportGroupProjection;
+import com.example.auction.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminReportGroupDto {
+    private Long targetUserId;
+    private String targetName;
+    private String targetNickname;
+    private ReportCategory category;
+    private long pendingCount;
+    private long acceptedCount;
+    private long rejectedCount;
+    private boolean viewOnly;
+    private LocalDateTime suspendedUntil;
+    private long warning;
+    private LocalDateTime lastReportedAt;
+
+    public static AdminReportGroupDto fromEntity(ReportGroupProjection projection, User user) {
+        return AdminReportGroupDto.builder()
+                .targetUserId(projection.getTargetId())
+                .targetName(user != null ? user.getName() : null)
+                .targetNickname(user != null ? user.getNickname() : null)
+                .category(projection.getCategory())
+                .pendingCount(Optional.ofNullable(projection.getPendingCount()).orElse(0L))
+                .acceptedCount(Optional.ofNullable(projection.getAcceptedCount()).orElse(0L))
+                .rejectedCount(Optional.ofNullable(projection.getRejectedCount()).orElse(0L))
+                .viewOnly(user != null && Boolean.TRUE.equals(user.getViewOnly()))
+                .suspendedUntil(user != null ? user.getSuspendedUntil() : null)
+                .warning(user != null && user.getWarning() != null ? user.getWarning() : 0L)
+                .lastReportedAt(projection.getLastReportedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/auction/report/repository/ReportGroupProjection.java
+++ b/src/main/java/com/example/auction/report/repository/ReportGroupProjection.java
@@ -1,0 +1,14 @@
+package com.example.auction.report.repository;
+
+import com.example.auction.report.domain.ReportCategory;
+
+import java.time.LocalDateTime;
+
+public interface ReportGroupProjection {
+    Long getTargetId();
+    ReportCategory getCategory();
+    Long getPendingCount();
+    Long getAcceptedCount();
+    Long getRejectedCount();
+    LocalDateTime getLastReportedAt();
+}

--- a/src/main/java/com/example/auction/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/auction/report/repository/ReportRepository.java
@@ -13,4 +13,5 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     boolean existsByReporter_UserIdAndTargetIdAndCategory(Long reporterUserId, Long targetId, ReportCategory category);
 
     List<Report> findByTargetIdAndStatus(Long targetId, ReportStatus status);
+    List<Report> findByTargetIdAndCategoryAndStatus(Long targetId, ReportCategory category, ReportStatus status);
 }

--- a/src/main/java/com/example/auction/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/auction/report/repository/ReportRepository.java
@@ -3,15 +3,35 @@ package com.example.auction.report.repository;
 import com.example.auction.report.domain.Report;
 import com.example.auction.report.domain.ReportCategory;
 import com.example.auction.report.domain.ReportStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
     boolean existsByReporter_UserIdAndTargetIdAndCategory(Long reporterUserId, Long targetId, ReportCategory category);
 
-    List<Report> findByTargetIdAndStatus(Long targetId, ReportStatus status);
     List<Report> findByTargetIdAndCategoryAndStatus(Long targetId, ReportCategory category, ReportStatus status);
+
+    // 관리자 그룹 요약 집계
+    @Query("""
+        select 
+          r.targetId as targetId,
+          r.category as category,
+          sum(case when r.status = com.example.auction.report.domain.ReportStatus.PENDING then 1 else 0 end) as pendingCount,
+          sum(case when r.status = com.example.auction.report.domain.ReportStatus.ACCEPTED then 1 else 0 end) as acceptedCount,
+          sum(case when r.status = com.example.auction.report.domain.ReportStatus.REJECTED then 1 else 0 end) as rejectedCount,
+          max(r.createdAt) as lastReportedAt
+        from Report r
+        group by r.targetId, r.category
+        """)
+    List<ReportGroupProjection> aggregateReportGroups();
+
+    // 그룹 상세 페이징
+    Page<Report> findByTargetIdAndCategory(Long targetId, ReportCategory category, Pageable pageable);
 }

--- a/src/main/java/com/example/auction/report/service/ReportService.java
+++ b/src/main/java/com/example/auction/report/service/ReportService.java
@@ -4,9 +4,11 @@ import com.example.auction.common.domain.DelYN;
 import com.example.auction.report.domain.Report;
 import com.example.auction.report.domain.ReportCategory;
 import com.example.auction.report.domain.ReportStatus;
+import com.example.auction.report.dto.AdminReportGroupDto;
 import com.example.auction.report.dto.AdminResolveDto;
 import com.example.auction.report.dto.ReportCreateDto;
 import com.example.auction.report.dto.ReportResponseDto;
+import com.example.auction.report.repository.ReportGroupProjection;
 import com.example.auction.report.repository.ReportRepository;
 import com.example.auction.user.domain.User;
 import com.example.auction.user.domain.UserReportAggregate;
@@ -14,6 +16,8 @@ import com.example.auction.user.repository.UserReportAggregateRepository;
 import com.example.auction.user.repository.UserRepository;
 import com.example.auction.user.service.UserService;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.ScanOptions;
@@ -26,15 +30,15 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 public class ReportService {
     private final ReportRepository reportRepository;
     private final UserRepository userRepository;
-    private final UserReportAggregateRepository aggRepository;
+    private final UserReportAggregateRepository aggRepository;//
     private final UserService userService;
 
     private final StringRedisTemplate reportCounter;
@@ -58,7 +62,6 @@ public class ReportService {
         this.safeDecrPendingScript = safeDecrPendingScript;
     }
 
-    // ---------- Redis Key Helper ----------
     private String pendingKey(Long userId, ReportCategory category) {
         return "report:pending:{" + userId + ":" + category.name() + "}";
     }
@@ -69,7 +72,7 @@ public class ReportService {
         return "report:pending:total:{" + userId + "}";
     }
 
-    // ---------- Helpers ----------
+    // 계산관련
     private long incr(String key, long delta) {
         Long v = reportCounter.opsForValue().increment(key, delta);
         return v == null ? 0L : v;
@@ -208,6 +211,56 @@ public class ReportService {
 
         upsertAggregateSnapshot(targetUserId, category);
     }
+
+    /* [관리자] 신고여부에 따른 그룹핑 조회 (신고당한사람 + 카테고리 )*/
+    @Transactional(readOnly = true)
+    public List<AdminReportGroupDto> getAdminReportGroups(ReportCategory category,
+                                                          ReportStatus status,
+                                                          Integer minPending,
+                                                          Long targetUserId) {
+        userService.checkAdminAuthority();
+
+        var rows = reportRepository.aggregateReportGroups();
+
+        // 필터
+        var filtered = rows.stream()
+                .filter(projection -> category == null || projection.getCategory() == category)
+                .filter(projection -> targetUserId == null || Objects.equals(projection.getTargetId(), targetUserId))
+                .filter(projection -> {
+                    if (status == null) return true;
+                    return switch (status) {
+                        case PENDING  -> (projection.getPendingCount()  != null && projection.getPendingCount()  > 0);
+                        case ACCEPTED -> (projection.getAcceptedCount() != null && projection.getAcceptedCount() > 0);
+                        case REJECTED -> (projection.getRejectedCount() != null && projection.getRejectedCount() > 0);
+                    };
+                })
+                .filter(projection -> {
+                    if (minPending == null) return true;
+                    long pc = projection.getPendingCount() == null ? 0L : projection.getPendingCount();
+                    return pc >= minPending;
+                })
+                .toList();
+
+        // 타겟 정보 배치 조회
+        var ids = filtered.stream().map(ReportGroupProjection::getTargetId).collect(Collectors.toSet());
+        Map<Long, User> userMap = userRepository.findAllById(ids).stream()
+                .filter(u -> u.getDelYn() == DelYN.N)
+                .collect(Collectors.toMap(User::getUserId, Function.identity()));
+
+        return filtered.stream()
+                .map(projection -> AdminReportGroupDto.fromEntity(projection, userMap.get(projection.getTargetId())))
+                .sorted(Comparator.comparing(AdminReportGroupDto::getLastReportedAt,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
+                .toList();
+    }
+
+    /* [관리자] 그룹핑 조회에 따른 상세 조회*/
+    @Transactional(readOnly = true)
+    public Page<Report> getGroupReports(Long targetUserId, ReportCategory category, Pageable pageable) {
+        userService.checkAdminAuthority();
+        return reportRepository.findByTargetIdAndCategory(targetUserId, category, pageable);
+    }
+
 
     /* [관리자] 즉시 정지 */
     @Transactional

--- a/src/main/java/com/example/auction/report/service/ReportService.java
+++ b/src/main/java/com/example/auction/report/service/ReportService.java
@@ -149,13 +149,24 @@ public class ReportService {
     public void adminResolveCategoryForUser(Long targetUserId, ReportCategory category, AdminResolveDto dto) {
         userService.checkAdminAuthority();
 
+        if (category == null) throw new IllegalArgumentException("카테고리를 지정해 주세요.");
+        if (dto == null) throw new IllegalArgumentException("요청 본문이 비었습니다.");
+
+        if (!dto.isAccept() && dto.getSuspendDays() != null) {
+            throw new IllegalArgumentException("반려 처리에서는 정지일수를 지정할 수 없습니다.");
+        }
+        if (dto.isAccept() && dto.getSuspendDays() != null && dto.getSuspendDays() < 0) {
+            throw new IllegalArgumentException("정지 일수는 0 이상이어야 합니다.");
+        }
+
         User target = userRepository.findByUserIdAndDelYn(targetUserId, DelYN.N)
                 .orElseThrow(() -> new RuntimeException("대상 유저가 존재하지 않거나 비활성화 상태입니다."));
 
         List<Report> pendings = reportRepository
                 .findByTargetIdAndCategoryAndStatus(targetUserId, category, ReportStatus.PENDING);
-        if (pendings.isEmpty()) return;
-
+        if (pendings.isEmpty()) {
+            throw new IllegalStateException("해당 유저(" + targetUserId + ")의 " + category + " 카테고리에 대기중 신고가 없습니다.");
+        }
         int size = pendings.size();
 
         if (dto.isAccept()) {

--- a/src/main/java/com/example/auction/report/service/ReportService.java
+++ b/src/main/java/com/example/auction/report/service/ReportService.java
@@ -13,11 +13,21 @@ import com.example.auction.user.domain.UserReportAggregate;
 import com.example.auction.user.repository.UserReportAggregateRepository;
 import com.example.auction.user.repository.UserRepository;
 import com.example.auction.user.service.UserService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -27,16 +37,64 @@ public class ReportService {
     private final UserReportAggregateRepository aggRepository;
     private final UserService userService;
 
+    private final StringRedisTemplate reportCounter;
+    private final DefaultRedisScript<Long> movePendingToAcceptedScript;
+    private final DefaultRedisScript<Long> safeDecrPendingScript;
 
-    public ReportService(ReportRepository reportRepository, UserRepository userRepository, UserReportAggregateRepository aggRepository, UserService userService) {
+
+    public ReportService(ReportRepository reportRepository,
+                         UserRepository userRepository,
+                         UserReportAggregateRepository aggRepository,
+                         UserService userService,
+                         @Qualifier("reportCounter") StringRedisTemplate reportCounter,
+                         @Qualifier("movePendingToAcceptedScript") DefaultRedisScript<Long> movePendingToAcceptedScript,
+                         @Qualifier("safeDecrPendingScript") DefaultRedisScript<Long> safeDecrPendingScript) {
         this.reportRepository = reportRepository;
         this.userRepository = userRepository;
         this.aggRepository = aggRepository;
         this.userService = userService;
+        this.reportCounter = reportCounter;
+        this.movePendingToAcceptedScript = movePendingToAcceptedScript;
+        this.safeDecrPendingScript = safeDecrPendingScript;
     }
 
+    // ---------- Redis Key Helper ----------
+    private String pendingKey(Long userId, ReportCategory category) {
+        return "report:pending:{" + userId + ":" + category.name() + "}";
+    }
+    private String acceptedKey(Long userId, ReportCategory category) {
+        return "report:accepted:{" + userId + ":" + category.name() + "}";
+    }
+    private String totalPendingKey(Long userId) {
+        return "report:pending:total:{" + userId + "}";
+    }
+
+    // ---------- Helpers ----------
+    private long incr(String key, long delta) {
+        Long v = reportCounter.opsForValue().increment(key, delta);
+        return v == null ? 0L : v;
+    }
+    private long getLong(String key) {
+        String v = reportCounter.opsForValue().get(key);
+        return (v == null) ? 0L : Long.parseLong(v);
+    }
+    private long getTotalPending(Long userId) { return getLong(totalPendingKey(userId)); }
+    private void safeDecr(String key, long n) {
+        reportCounter.execute(safeDecrPendingScript, Collections.singletonList(key), String.valueOf(n));
+    }
     private static final long PENDING_THRESHOLD_PER_CATEGORY = 5L;
 
+    /** Redis 카운터 → DB 스냅샷 업서트 */
+    @Transactional
+    protected void upsertAggregateSnapshot(Long targetUserId, ReportCategory category) {
+        long pending = getLong(pendingKey(targetUserId, category));
+        long accepted = getLong(acceptedKey(targetUserId, category));
+        UserReportAggregate agg = aggRepository.findByTargetUserIdAndCategory(targetUserId, category)
+                .orElseGet(() -> UserReportAggregate.init(targetUserId, category));
+        agg.setPendingCount(pending);
+        agg.setAcceptedCount(accepted);
+        aggRepository.save(agg);
+    }
 
     /* 신고하기 */
     @Transactional
@@ -60,17 +118,25 @@ public class ReportService {
         Report report = dto.toEntity(reporter);
         reportRepository.save(report);
 
-        UserReportAggregate aggregate = aggRepository
-                .findByTargetUserIdAndCategory(dto.getTargetId(), dto.getCategory())
-                .orElse(UserReportAggregate.init(dto.getTargetId(), dto.getCategory()));
-        aggregate.increasePending();
-        aggRepository.save(aggregate);
+        long newPending = incr(pendingKey(dto.getTargetId(), dto.getCategory()), 1L);
+        incr(totalPendingKey(dto.getTargetId()), 1L);
 
-        // 임계치까지 신고 접수 시 조회가능 메서드
-        if (aggregate.getPendingCount() >= PENDING_THRESHOLD_PER_CATEGORY && !Boolean.TRUE.equals(target.getViewOnly())) {
+        if (newPending >= PENDING_THRESHOLD_PER_CATEGORY && Boolean.FALSE.equals(target.getViewOnly())) {
             target.makeViewOnly();
             userRepository.save(target);
         }
+
+//        UserReportAggregate aggregate = aggRepository
+//                .findByTargetUserIdAndCategory(dto.getTargetId(), dto.getCategory())
+//                .orElse(UserReportAggregate.init(dto.getTargetId(), dto.getCategory()));
+//        aggregate.increasePending();
+//        aggRepository.save(aggregate);
+//
+//        // 임계치까지 신고 접수 시 조회가능 메서드
+//        if (aggregate.getPendingCount() >= PENDING_THRESHOLD_PER_CATEGORY && !Boolean.TRUE.equals(target.getViewOnly())) {
+//            target.makeViewOnly();
+//            userRepository.save(target);
+//        }
 
         return ReportResponseDto.fromEntity(report);
     }
@@ -83,48 +149,67 @@ public class ReportService {
         User target = userRepository.findByUserIdAndDelYn(targetUserId, DelYN.N)
                 .orElseThrow(() -> new RuntimeException("대상 유저가 존재하지 않거나 비활성화 상태입니다."));
 
-        List<Report> pendings = reportRepository.findByTargetIdAndStatus(targetUserId, ReportStatus.PENDING)
-                .stream().filter(r -> r.getCategory() == category).toList();
+        List<Report> pendings = reportRepository
+                .findByTargetIdAndCategoryAndStatus(targetUserId, category, ReportStatus.PENDING);
         if (pendings.isEmpty()) return;
 
-        UserReportAggregate aggregate = aggRepository
-                .findByTargetUserIdAndCategory(targetUserId, category)
-                .orElseThrow(() -> new RuntimeException("집계 정보가 없습니다."));
+        int size = pendings.size();
 
         if (dto.isAccept()) {
-            // 승인 관련
+            // 1) 신고 ACCEPT
             pendings.forEach(r -> r.accept(dto.getAdminContent()));
             reportRepository.saveAll(pendings);
 
-            aggregate.movePendingToAccepted(pendings.size());
-            aggRepository.save(aggregate);
+            // 2) Redis: pending→accepted 이동(카테고리 원자 이동), 총합 pending 감소
+            reportCounter.execute(
+                    movePendingToAcceptedScript,
+                    Arrays.asList(pendingKey(targetUserId, category), acceptedKey(targetUserId, category)),
+                    String.valueOf(size)
+            );
+            reportCounter.execute(
+                    safeDecrPendingScript,
+                    Collections.singletonList(totalPendingKey(targetUserId)),
+                    String.valueOf(size)
+            );
 
+            // 3) 제재
             if (dto.getSuspendDays() != null && dto.getSuspendDays() > 0) {
                 target.suspendUntil(LocalDateTime.now().plusDays(dto.getSuspendDays()));
-                target.cancelViewOnly();
+                target.cancelViewOnly(); // 정책 따라 유지 가능
             } else {
                 target.setWarning(target.getWarning() + 1);
-                // viewOnly 유지/해제는 정책에 따라 다를 수 있음(여기서는 유지)
+                // viewOnly 유지 (정책에 따라 조정)
             }
             userRepository.save(target);
 
         } else {
-            //  취소 관련
+            // REJECT: 신고 REJECT, 카테고리 pending 감소, 총합 pending 감소
             pendings.forEach(r -> r.reject(dto.getAdminContent()));
             reportRepository.saveAll(pendings);
 
-            aggregate.decreasePending(pendings.size());
-            aggRepository.save(aggregate);
+            reportCounter.execute(
+                    safeDecrPendingScript,
+                    Collections.singletonList(pendingKey(targetUserId, category)),
+                    String.valueOf(size)
+            );
+            reportCounter.execute(
+                    safeDecrPendingScript,
+                    Collections.singletonList(totalPendingKey(targetUserId)),
+                    String.valueOf(size)
+            );
 
-            // 임계치 미만이면 임시정지 해제
-            if (aggregate.getPendingCount() < PENDING_THRESHOLD_PER_CATEGORY && Boolean.TRUE.equals(target.getViewOnly())) {
+            // 총합이 임계 미만이면 viewOnly 해제
+            long total = getTotalPending(targetUserId);
+            if (total < PENDING_THRESHOLD_PER_CATEGORY && Boolean.TRUE.equals(target.getViewOnly())) {
                 target.cancelViewOnly();
                 userRepository.save(target);
             }
         }
+
+        upsertAggregateSnapshot(targetUserId, category);
     }
 
-    /* 개별 즉시 정지 / 해제 */
+    /* [관리자] 즉시 정지 */
     @Transactional
     public void adminSuspendUser(Long targetUserId, long days, String reason) {
         userService.checkAdminAuthority();
@@ -135,7 +220,6 @@ public class ReportService {
         target.suspendUntil(LocalDateTime.now().plusDays(days));
         target.cancelViewOnly();
         userRepository.save(target);
-        // 필요시 AdminActionLog 기록 등
     }
 
     /* 상태 복구 */

--- a/src/main/java/com/example/auction/user/domain/UserReportAggregate.java
+++ b/src/main/java/com/example/auction/user/domain/UserReportAggregate.java
@@ -13,7 +13,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name = "user_report_aggregate")
+@Table(
+        name = "user_report_aggregate",
+        uniqueConstraints = @UniqueConstraint(name="uk_user_report_agg", columnNames = {"target_user_id","category"})
+)
 public class UserReportAggregate extends BaseTimeEntity {
 
     @Id
@@ -32,6 +35,9 @@ public class UserReportAggregate extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Long acceptedCount;
+
+    @Version
+    private Long version;
 
     public static UserReportAggregate init(Long targetUserId, ReportCategory category) {
         UserReportAggregate aggregate = new UserReportAggregate();

--- a/src/main/java/com/example/auction/user/repository/UserReportAggregateRepository.java
+++ b/src/main/java/com/example/auction/user/repository/UserReportAggregateRepository.java
@@ -4,8 +4,10 @@ import com.example.auction.report.domain.ReportCategory;
 import com.example.auction.user.domain.UserReportAggregate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserReportAggregateRepository extends JpaRepository<UserReportAggregate, Long> {
     Optional<UserReportAggregate> findByTargetUserIdAndCategory(Long targetUserId, ReportCategory category);
+    List<UserReportAggregate> findAllByTargetUserId(Long targetUserId);
 }

--- a/src/main/java/com/example/auction/user/service/UserService.java
+++ b/src/main/java/com/example/auction/user/service/UserService.java
@@ -159,11 +159,13 @@ public class UserService {
 
     /* 관리자 여부 확인 */
     @Transactional(readOnly = true)
-    public boolean checkAdminAuthority() {
+    public void checkAdminAuthority() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         User user = userRepository.findByEmailAndDelYn(email, DelYN.N)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 유저입니다."));
-        return user.getAuthority() == Authority.ADMIN;
+        if (user.getAuthority() != Authority.ADMIN) {
+            throw new org.springframework.security.access.AccessDeniedException("관리자만 접근 가능합니다.");
+        }
     }
 
     /* 닉네임 생성 및 업데이트 */

--- a/src/main/java/com/example/auction/user/service/UserService.java
+++ b/src/main/java/com/example/auction/user/service/UserService.java
@@ -54,6 +54,10 @@ public class UserService {
             throw new RuntimeException("탈퇴된 계정입니다.");
         }
 
+        if (user.getSuspendedUntil() != null && LocalDateTime.now().isBefore(user.getSuspendedUntil())) {
+            throw new RuntimeException("정지된 계정입니다. 해제 시각: " + user.getSuspendedUntil());
+        }
+
         if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
             throw new RuntimeException("비밀번호가 일치하지 않습니다.");
         }


### PR DESCRIPTION
현 상태 유저 > 유저 신고 기능 구현
1. 유저가 카테고리, 신고대상자, 신고커멘트를 입력하여 다른 유저를 신고한다
2. 해당 신고 내역을 그룹별로 관리자는 조회할 수 있다
3. 최소그룹(같은 카테고리로 5개) 가 된 신고는 조회가능하며 승인/거절에 대한 처리가 가능하다

동시성 처리를 위해서 redis 및 경쟁제어을 위한 redis + lua(함수 사용- 간단 수식시 사용)
이후 조회 성능을 올리기 위한 @query 사용